### PR TITLE
Create  withdrawal fail

### DIFF
--- a/withdrawal fail
+++ b/withdrawal fail
@@ -1,0 +1,2 @@
+when trying to send BTC -  "Error or the hot wallet is empty and sound will be Fund" http://prntscr.com/iknszk
+am asking deal. thank you.


### PR DESCRIPTION
when trying to send BTC -  "Error or the hot wallet is empty and sound will be Fund" http://prntscr.com/iknszk
Please fix. 
Thank you.